### PR TITLE
Add loongarch64 support

### DIFF
--- a/raw/src/lib.rs
+++ b/raw/src/lib.rs
@@ -57,6 +57,7 @@ cfg_if! {
         target_arch = "sparc",
         target_arch = "sparc64",
         target_arch = "aarch64",
+        target_arch = "loongarch64",
     ))] {
         pub use x32::*;
     } else if #[cfg(any(


### PR DESCRIPTION
Hi maintainer,

Compiling the rust-utmp-classic-raw failed for loong64 in the Debian Package Auto-Building environment.
The error log is as follows,
```
error: The target platform is not supported, please help us add it.
  --> src/lib.rs:67:9
   |
67 |         compile_error!("The target platform is not supported, please help us add it.");
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
......
```
The full build log can be found at https://buildd.debian.org/status/fetch.php?pkg=rust-utmp-classic-raw&arch=loong64&ver=0.1.3-1%2Bb1&stamp=1740507047&raw=0.

Please review this PR, thanks.